### PR TITLE
Add cross-env

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,15 +1,16 @@
 {
   "name": "hype-autofill",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "private": true,
   "dependencies": {
+    "cross-env": "^6.0.3",
     "react": "^16.11.0",
     "react-dom": "^16.11.0",
     "react-scripts": "3.2.0"
   },
   "scripts": {
     "start": "react-scripts start",
-    "build": "INLINE_RUNTIME_CHUNK=false react-scripts build",
+    "build": "cross-env INLINE_RUNTIME_CHUNK=false react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject"
   },


### PR DESCRIPTION
Fixes Windows not recognizing **INLINE_RUNTIME_CHUNK** in the build script